### PR TITLE
Stops adding values to array if number of columns is reached.

### DIFF
--- a/src/Google/Spreadsheet/ListFeed.php
+++ b/src/Google/Spreadsheet/ListFeed.php
@@ -96,6 +96,9 @@ class ListFeed
                 $vals = array();
                 foreach($cols as $col) {
                     $vals[] = $col->__toString();
+					if (count($vals)===count($colNames)) {
+						break;
+					}
                 }
                 $rows[] = new ListEntry($entry, array_combine($colNames, $vals));
                 


### PR DESCRIPTION
The columNames are created only once. If anywhere in the sheet there is an extra value in one of the rows, the array_combine function fails and returns an empty row. This should fix it.
