### PR TITLE
Add 404 http code to handle 'you need permission' exception.

### DIFF
--- a/src/Google/Spreadsheet/DefaultServiceRequest.php
+++ b/src/Google/Spreadsheet/DefaultServiceRequest.php
@@ -236,10 +236,15 @@ class DefaultServiceRequest implements ServiceRequestInterface
         $httpCode = (int)$info['http_code'];
 
         if($httpCode > 299) {
-            if($httpCode === 401) {
-                throw new UnauthorizedException('Access token is invalid', 401);
-            } else {
-                throw new Exception('Error in Google Request', $info['http_code']);
+            switch ($httpCode) {
+                case 401:
+                    throw new UnauthorizedException('Access token is invalid', 401);
+                    break;
+                case 404:
+                    throw new UnauthorizedException('You need permission', 404);
+                    break;
+                default:
+                    throw new Exception('Error in Google Request', $info['http_code']);
             }
         }
 


### PR DESCRIPTION
404 http code appears when user does not have read access to a file, or the file does not exist.