### PR TITLE
Bugfix for sending xml with special characters.

### DIFF
--- a/src/Google/Spreadsheet/Batch/BatchRequest.php
+++ b/src/Google/Spreadsheet/Batch/BatchRequest.php
@@ -89,6 +89,9 @@ class BatchRequest
      */
     protected function createEntry(CellEntry $cellEntry, $index, CellFeed $cellFeed)
     {
+        $htmlspchrsFlags = defined('ENT_XML1') ? ENT_COMPAT | ENT_XML1 : ENT_COMPAT; // backward compatibility for PHP5.3
+        $value = htmlspecialchars($cellEntry->getContent(), $htmlspchrsFlags, ini_get("default_charset"), false);
+
         return sprintf(
             '<entry>
                 <batch:id>%s</batch:id>
@@ -103,7 +106,7 @@ class BatchRequest
             $cellEntry->getEditUrl(),
             $cellEntry->getRow(),
             $cellEntry->getColumn(),
-            $cellEntry->getContent()
+            $value
         );
     }
     

--- a/src/Google/Spreadsheet/CellEntry.php
+++ b/src/Google/Spreadsheet/CellEntry.php
@@ -160,6 +160,9 @@ class CellEntry
      */
     public function update($value)
     {
+        $htmlspchrsFlags = defined('ENT_XML1') ? ENT_COMPAT | ENT_XML1 : ENT_COMPAT; // backward compatibility for PHP5.3
+        $value = htmlspecialchars($value, $htmlspchrsFlags, ini_get("default_charset"), false);
+
         $entry = sprintf('
             <entry xmlns="http://www.w3.org/2005/Atom"
                 xmlns:gs="http://schemas.google.com/spreadsheets/2006">

--- a/src/Google/Spreadsheet/CellFeed.php
+++ b/src/Google/Spreadsheet/CellFeed.php
@@ -112,6 +112,9 @@ class CellFeed
      */
     public function editCell($rowNum, $colNum, $value)
     {
+        $htmlspchrsFlags = defined('ENT_XML1') ? ENT_COMPAT | ENT_XML1 : ENT_COMPAT; // backward compatibility for PHP5.3
+        $value = htmlspecialchars($value, $htmlspchrsFlags, ini_get("default_charset"), false);
+
         $entry = sprintf('
             <entry xmlns="http://www.w3.org/2005/Atom" xmlns:gs="http://schemas.google.com/spreadsheets/2006">
               <gs:cell row="%u" col="%u" inputValue="%s"/>

--- a/src/Google/Spreadsheet/ListEntry.php
+++ b/src/Google/Spreadsheet/ListEntry.php
@@ -73,7 +73,10 @@ class ListEntry
         $entry = '<entry xmlns="http://www.w3.org/2005/Atom" xmlns:gsx="http://schemas.google.com/spreadsheets/2006/extended">';
         $entry .= '<id>'.$this->xml->id->__toString().'</id>';
 
+        $htmlspchrsFlags = defined('ENT_XML1') ? ENT_COMPAT | ENT_XML1 : ENT_COMPAT; // backward compatibility for PHP5.3
         foreach($values as $colName => $value) {
+            $value = htmlspecialchars($value, $htmlspchrsFlags, ini_get("default_charset"), false);
+            $colName = htmlspecialchars($colName, $htmlspchrsFlags, ini_get("default_charset"), false);
             $entry .= sprintf(
                 '<gsx:%s><![CDATA[%s]]></gsx:%s>',
                 $colName,

--- a/src/Google/Spreadsheet/ListFeed.php
+++ b/src/Google/Spreadsheet/ListFeed.php
@@ -66,7 +66,10 @@ class ListFeed
     public function insert($row)
     {
         $entry = '<entry xmlns="http://www.w3.org/2005/Atom" xmlns:gsx="http://schemas.google.com/spreadsheets/2006/extended">';
+        $htmlspchrsFlags = defined('ENT_XML1') ? ENT_COMPAT | ENT_XML1 : ENT_COMPAT; // backward compatibility for PHP5.3
         foreach($row as $colName => $value) {
+            $value = htmlspecialchars($value, $htmlspchrsFlags, ini_get("default_charset"), false);
+            $colName = htmlspecialchars($colName, $htmlspchrsFlags, ini_get("default_charset"), false);
             $entry .= sprintf(
                 '<gsx:%s><![CDATA[%s]]></gsx:%s>',
                 $colName,

--- a/src/Google/Spreadsheet/Spreadsheet.php
+++ b/src/Google/Spreadsheet/Spreadsheet.php
@@ -99,6 +99,9 @@ class Spreadsheet
      */
     public function addWorksheet($title, $rowCount=100, $colCount=10)
     {
+        $htmlspchrsFlags = defined('ENT_XML1') ? ENT_COMPAT | ENT_XML1 : ENT_COMPAT; // backward compatibility for PHP5.3
+        $title = htmlspecialchars($title, $htmlspchrsFlags, ini_get("default_charset"), false);
+
         $entry = sprintf('
             <entry xmlns="http://www.w3.org/2005/Atom" xmlns:gs="http://schemas.google.com/spreadsheets/2006">
                 <title>%s</title>


### PR DESCRIPTION
When sending special characters like <,> and & the xml gets broken. This is a fix using htmlspecialchars with the ENT_XML1 flag.

I think it would even be better to form all the xml using SimpleXML like hectorbenitez did. 
https://github.com/asimlqt/php-google-spreadsheet-client/pull/48/files

SimpleXML handles such cases for you.
