### PR TITLE
Added openSearch data getters for ListFeed object

### DIFF
--- a/src/Google/Spreadsheet/ListFeed.php
+++ b/src/Google/Spreadsheet/ListFeed.php
@@ -103,4 +103,22 @@ class ListFeed
         return $rows;
     }
 
+    public function getTotalResults()
+    {
+        $xml = $this->xml->children('openSearch', true);
+        return intval($xml->totalResults);
+    }
+
+    public function getItemsPerPage()
+    {
+        $xml = $this->xml->children('openSearch', true);
+        return intval($xml->itemsPerPage);
+    }
+
+    public function getStartIndex()
+    {
+        $xml = $this->xml->children('openSearch', true);
+        return intval($xml->startIndex);
+    }
+
 }


### PR DESCRIPTION
I needed the `totalResults` of a ListFeed object and noticed there were no getters to retrieve this property. I added data getters for the three openSearch properties:
- `totalResults`
- `itemsPerPage`
- `startIndex`