### PR TITLE
Added detection of curl_exec failure

### DIFF
--- a/src/Google/Spreadsheet/DefaultServiceRequest.php
+++ b/src/Google/Spreadsheet/DefaultServiceRequest.php
@@ -230,7 +230,9 @@ class DefaultServiceRequest implements ServiceRequestInterface
      */
     protected function execute($ch)
     {
-        $ret = curl_exec($ch);
+        if (false == ($ret = curl_exec($ch))) {
+            throw new \RuntimeException(sprintf('Error on curl_exec: %s', curl_error($ch)));
+        }
 
         $info = curl_getinfo($ch);
         $httpCode = (int)$info['http_code'];


### PR DESCRIPTION
I've hit a little issue while using curl on windows due to SSL verification failure. I've discovered what happened after checking the ```curl_exec``` returned value and I've thought this little modification might be useful to have.