### PR TITLE
Cleaned up PHPDoc to resolve IDE warnings.

### DIFF
--- a/src/Google/Spreadsheet/Batch/BatchRequest.php
+++ b/src/Google/Spreadsheet/Batch/BatchRequest.php
@@ -43,7 +43,7 @@ class BatchRequest
     
     /**
      * 
-     * @param \Google\Spreadsheet\CellEntry $cellEntry
+     * @param CellEntry $cellEntry
      */
     public function addEntry(CellEntry $cellEntry)
     {
@@ -52,7 +52,7 @@ class BatchRequest
     
     /**
      * 
-     * @param \Google\Spreadsheet\CellFeed $cellFeed
+     * @param CellFeed $cellFeed
      * 
      * @return string|null
      */
@@ -81,9 +81,9 @@ class BatchRequest
 
     /**
      * 
-     * @param \Google\Spreadsheet\CellEntry $cellEntry
-     * @param string                        $index
-     * @param \Google\Spreadsheet\CellFeed  $cellFeed
+     * @param CellEntry $cellEntry
+     * @param string    $index
+     * @param CellFeed  $cellFeed
      * 
      * @return string
      */

--- a/src/Google/Spreadsheet/CellEntry.php
+++ b/src/Google/Spreadsheet/CellEntry.php
@@ -30,7 +30,7 @@ class CellEntry
     /**
      * Xml element for a cell entry
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     protected $xml;
 
@@ -65,7 +65,7 @@ class CellEntry
     /**
      * Constructor
      * 
-     * @param \SimpleXMLElement $xml
+     * @param SimpleXMLElement  $xml
      * @param string            $postUrl
      */
     public function __construct($xml, $postUrl)
@@ -73,6 +73,7 @@ class CellEntry
         $this->xml = $xml;
         $this->postUrl = $postUrl;
         $this->setCellLocation();
+        /** @noinspection PhpUndefinedFieldInspection */
         $this->content = $this->xml->content->__toString();
     }
 
@@ -128,6 +129,7 @@ class CellEntry
      */
     public function getTitle()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return $this->xml->title->__toString();
     }
 
@@ -176,11 +178,12 @@ class CellEntry
 
     /**
      * Get the location of the cell.
-     * 
-     * @return array
+     *
+     * @throws Exception
      */
     protected function setCellLocation()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         $id = $this->xml->id->__toString();
         preg_match('@/R(\d+)C(\d+)@', $id, $matches);
 

--- a/src/Google/Spreadsheet/CellFeed.php
+++ b/src/Google/Spreadsheet/CellFeed.php
@@ -32,7 +32,7 @@ class CellFeed
     /**
      * The xml representation of the feed
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     protected $xml;
 
@@ -56,7 +56,7 @@ class CellFeed
     /**
      * Get the feed entries
      * 
-     * @return array \Google\Spreadsheet\CellEntry
+     * @return CellEntry[]
      */
     public function getEntries()
     {
@@ -66,6 +66,7 @@ class CellFeed
             
         $postUrl = $this->getPostUrl();
 
+        /** @noinspection PhpUndefinedFieldInspection */
         foreach ($this->xml->entry as $entry) {
             $cell = new CellEntry($entry, $postUrl);
             $this->entries[$cell->getCellIdString()] = $cell;
@@ -76,8 +77,8 @@ class CellFeed
 
     /**
      * 
-     * @param type $row
-     * @param type $col
+     * @param int $row
+     * @param int $col
      * 
      * @return CellEntry|null
      */
@@ -126,9 +127,9 @@ class CellFeed
 
     /**
      * 
-     * @param \Google\Spreadsheet\Batch\BatchRequest $batchRequest
+     * @param BatchRequest $batchRequest
      * 
-     * @return \Google\Spreadsheet\Batch\BatchResponse
+     * @return BatchResponse
      */
     public function updateBatch(BatchRequest $batchRequest)
     {
@@ -139,9 +140,9 @@ class CellFeed
 
     /**
      *
-     * @param \Google\Spreadsheet\Batch\BatchRequest $batchRequest
+     * @param BatchRequest $batchRequest
      *
-     * @return \Google\Spreadsheet\Batch\BatchResponse
+     * @return BatchResponse
      */
     public function insertBatch(BatchRequest $batchRequest)
     {

--- a/src/Google/Spreadsheet/DefaultServiceRequest.php
+++ b/src/Google/Spreadsheet/DefaultServiceRequest.php
@@ -26,9 +26,9 @@ namespace Google\Spreadsheet;
 class DefaultServiceRequest implements ServiceRequestInterface
 {
     /**
-     * Request object
+     * Access token
      * 
-     * @var \Google\Spreadsheet\Request
+     * @var string
      */
     protected $accessToken;
 
@@ -83,11 +83,7 @@ class DefaultServiceRequest implements ServiceRequestInterface
     }
     
     /**
-     * Set optional request headers. 
-     * 
-     * @param array $headers associative array of key value pairs
-     *
-     * @return Google\Spreadsheet\DefaultServiceRequest
+     * {@inheritdoc}
      */
     public function setHeaders(array $headers)
     {
@@ -110,7 +106,7 @@ class DefaultServiceRequest implements ServiceRequestInterface
      * 
      * @param string $userAgent
      *
-     * @return Google\Spreadsheet\DefaultServiceRequest
+     * @return DefaultServiceRequest
      */
     public function setUserAgent($userAgent)
     {
@@ -119,11 +115,7 @@ class DefaultServiceRequest implements ServiceRequestInterface
     }
 
     /**
-     * Perform a get request
-     * 
-     * @param string $url
-     * 
-     * @return string
+     * {@inheritdoc}
      */
     public function get($url)
     {
@@ -133,12 +125,7 @@ class DefaultServiceRequest implements ServiceRequestInterface
     }
 
     /**
-     * Perform a post request
-     *
-     * @param string $url
-     * @param mixed  $postData
-     * 
-     * @return string
+     * {@inheritdoc}
      */
     public function post($url, $postData)
     {   
@@ -153,12 +140,7 @@ class DefaultServiceRequest implements ServiceRequestInterface
     }
 
     /**
-     * Perform a put request
-     * 
-     * @param string $url
-     * @param mixed  $postData
-     * 
-     * @return string
+     * {@inheritdoc}
      */
     public function put($url, $postData)
     {
@@ -173,11 +155,7 @@ class DefaultServiceRequest implements ServiceRequestInterface
     }
 
     /**
-     * Perform a delete request
-     * 
-     * @param string $url
-     * 
-     * @return string
+     * {@inheritdoc}
      */
     public function delete($url)
     {
@@ -228,14 +206,15 @@ class DefaultServiceRequest implements ServiceRequestInterface
 
     /**
      * Executes the api request.
-     * 
+     *
+     * @param  resource $ch
      * @return string the xml response
      *
-     * @throws \Google\Spreadsheet\Exception If the was a problem with the request.
-     *                                       Will throw an exception if the response
-     *                                       code is 300 or greater
-     *                                       
-     * @throws \Google\Spreadsheet\UnauthorizedException
+     * @throws Exception If the was a problem with the request.
+     *                   Will throw an exception if the response
+     *                   code is 300 or greater
+     *
+     * @throws UnauthorizedException
      */
     protected function execute($ch)
     {

--- a/src/Google/Spreadsheet/ListEntry.php
+++ b/src/Google/Spreadsheet/ListEntry.php
@@ -16,7 +16,7 @@
  */
 namespace Google\Spreadsheet;
 
-use Google\Spreadsheet\Util;
+use SimpleXMLElement;
 
 /**
  * List Entry
@@ -30,7 +30,7 @@ class ListEntry
     /**
      * The xml representation of this list entry
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     protected $xml;
 
@@ -44,7 +44,7 @@ class ListEntry
     /**
      * Constructor
      * 
-     * @param \SimpleXMLElement $xml
+     * @param SimpleXMLElement  $xml
      * @param array             $data
      */
     public function __construct($xml, $data)

--- a/src/Google/Spreadsheet/ListFeed.php
+++ b/src/Google/Spreadsheet/ListFeed.php
@@ -30,7 +30,7 @@ class ListFeed
     /**
      * Xml representation of this feed
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     protected $xml;
 
@@ -82,7 +82,7 @@ class ListFeed
     /**
      * Get the entries of this feed
      * 
-     * @return array \Google\Spreadsheet\ListEntry
+     * @return array ListEntry
      */
     public function getEntries()
     {

--- a/src/Google/Spreadsheet/ServiceRequestFactory.php
+++ b/src/Google/Spreadsheet/ServiceRequestFactory.php
@@ -42,7 +42,7 @@ class ServiceRequestFactory
      * 
      * @return ServiceRequestInterface
      * 
-     * @throws \Google\Spreadsheet\Exception
+     * @throws Exception
      */
     public static function getInstance()
     {

--- a/src/Google/Spreadsheet/ServiceRequestInterface.php
+++ b/src/Google/Spreadsheet/ServiceRequestInterface.php
@@ -25,8 +25,50 @@ namespace Google\Spreadsheet;
  */
 interface ServiceRequestInterface
 {
+    /**
+     * Perform a get request
+     *
+     * @param string $url
+     *
+     * @return string
+     */
     public function get($url);
+
+    /**
+     * Perform a post request
+     *
+     * @param string $url
+     * @param mixed  $postData
+     *
+     * @return string
+     */
     public function post($url, $postData);
+
+    /**
+     * Perform a put request
+     *
+     * @param string $url
+     * @param mixed  $postData
+     *
+     * @return string
+     */
     public function put($url, $postData);
+
+    /**
+     * Perform a delete request
+     *
+     * @param string $url
+     *
+     * @return string
+     */
     public function delete($url);
+
+    /**
+     * Set optional request headers.
+     *
+     * @param array $headers associative array of key value pairs
+     *
+     * @return DefaultServiceRequest
+     */
+    public function setHeaders(array $headers);
 }

--- a/src/Google/Spreadsheet/Spreadsheet.php
+++ b/src/Google/Spreadsheet/Spreadsheet.php
@@ -33,7 +33,7 @@ class Spreadsheet
     /**
      * The spreadsheet xml object
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     protected $xml;
 
@@ -54,6 +54,7 @@ class Spreadsheet
      */
     public function getId()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return $this->xml->id->__toString();
     }
 
@@ -64,6 +65,7 @@ class Spreadsheet
      */
     public function getUpdated()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return new DateTime($this->xml->updated->__toString());
     }
 
@@ -74,13 +76,14 @@ class Spreadsheet
      */
     public function getTitle()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return $this->xml->title->__toString();
     }
 
     /**
      * Get all the worksheets which belong to this spreadsheet
      * 
-     * @return \Google\Spreadsheet\WorksheetFeed
+     * @return WorksheetFeed
      */
     public function getWorksheets()
     {
@@ -95,7 +98,7 @@ class Spreadsheet
      * @param int    $rowCount default is 100
      * @param int    $colCount default is 10
      *
-     * @return \Google\Spreadsheet\Worksheet
+     * @return Worksheet
      */
     public function addWorksheet($title, $rowCount=100, $colCount=10)
     {

--- a/src/Google/Spreadsheet/SpreadsheetFeed.php
+++ b/src/Google/Spreadsheet/SpreadsheetFeed.php
@@ -31,7 +31,7 @@ class SpreadsheetFeed extends ArrayIterator
     /**
      * The spreadsheet feed xml object
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     protected $xml;
 
@@ -52,17 +52,19 @@ class SpreadsheetFeed extends ArrayIterator
     }
 
     /**
-     * Gets a spreadhseet from the feed by its title. i.e. the name of 
+     * Gets a spreadsheet from the feed by its title. i.e. the name of
      * the spreadsheet in google drive. This method will return only the
      * first spreadsheet found with the specified title.
      * 
      * @param string $title
      * 
-     * @return \Google\Spreadsheet\Spreadsheet|null
+     * @return Spreadsheet|null
      */
     public function getByTitle($title)
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         foreach($this->xml->entry as $entry) {
+            /** @noinspection PhpUndefinedFieldInspection */
             if($entry->title->__toString() == $title) {
                 return new Spreadsheet($entry);
             }

--- a/src/Google/Spreadsheet/SpreadsheetService.php
+++ b/src/Google/Spreadsheet/SpreadsheetService.php
@@ -28,9 +28,9 @@ use SimpleXMLElement;
 class SpreadsheetService
 {
     /**
-     * Fetches a list of spreadhsheet spreadsheets from google drive.
+     * Fetches a list of spreadsheet spreadsheets from google drive.
      *
-     * @return \Google\Spreadsheet\SpreadsheetFeed
+     * @return SpreadsheetFeed
      */
     public function getSpreadsheets()
     {
@@ -45,7 +45,7 @@ class SpreadsheetService
      *
      * @param string $id the url of the spreadsheet
      *
-     * @return \Google\Spreadsheet\Spreadsheet
+     * @return Spreadsheet
      */
     public function getSpreadsheetById($id)
     {
@@ -59,11 +59,11 @@ class SpreadsheetService
     /**
      * Returns a list feed of the specified worksheet.
      * 
-     * @see \Google\Spreadsheet\Worksheet::getWorksheetId()
+     * @see Worksheet::getWorksheetId()
      * 
      * @param string $worksheetId
      * 
-     * @return \Google\Spreadsheet\ListFeed
+     * @return ListFeed
      */
     public function getListFeed($worksheetId)
     {
@@ -75,11 +75,11 @@ class SpreadsheetService
     /**
      * Returns a cell feed of the specified worksheet.
      * 
-     * @see \Google\Spreadsheet\Worksheet::getWorksheetId()
+     * @see Worksheet::getWorksheetId()
      * 
      * @param string $worksheetId
      * 
-     * @return \Google\Spreadsheet\CellFeed
+     * @return CellFeed
      */
     public function getCellFeed($worksheetId)
     {

--- a/src/Google/Spreadsheet/Util.php
+++ b/src/Google/Spreadsheet/Util.php
@@ -41,15 +41,17 @@ class Util
 
     /**
      * Extracts the href for a specific rel from an xml object.
-     * 
-     * @param  \SimpleXMLElement $xml
-     * @param  string            $rel the value of the rel attribute whose href you want
-     * 
+     *
+     * @param  SimpleXMLElement $xml
+     * @param  string $rel the value of the rel attribute whose href you want
      * @return string
+     * @throws Exception
      */
     public static function getLinkHref(SimpleXMLElement $xml, $rel)
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         foreach($xml->link as $link) {
+            /** @var SimpleXMLElement[] $attributes */
             $attributes = $link->attributes();
             if($attributes['rel']->__toString() === $rel) {
                 return $attributes['href']->__toString();

--- a/src/Google/Spreadsheet/Worksheet.php
+++ b/src/Google/Spreadsheet/Worksheet.php
@@ -31,7 +31,7 @@ class Worksheet
     /**
      * A worksheet xml object
      *
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     private $xml;
 
@@ -55,6 +55,7 @@ class Worksheet
      */
     public function getId()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return $this->xml->id->__toString();
     }
 
@@ -66,10 +67,13 @@ class Worksheet
      */
     public function getWorksheetId()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         $parts = explode("/", $this->xml->id->__toString());
         if(count($parts) === 9) {
             return $parts[5];
         }
+
+        return null;
     }
     
     /**
@@ -94,6 +98,7 @@ class Worksheet
      */
     public function getUpdated()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return new DateTime($this->xml->updated->__toString());
     }
 
@@ -104,6 +109,7 @@ class Worksheet
      */
     public function getTitle()
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         return $this->xml->title->__toString();
     }
 
@@ -134,7 +140,7 @@ class Worksheet
      *
      * @param array $query add additional query params to the url to sort/filter the results
      * 
-     * @return \Google\Spreadsheet\ListFeed
+     * @return ListFeed
      */
     public function getListFeed(array $query = array())
     {
@@ -149,8 +155,9 @@ class Worksheet
 
     /**
      * Get the cell feed of this worksheet
-     * 
-     * @return \Google\Spreadsheet\CellFeed
+     *
+     * @param   array   $query
+     * @return  CellFeed
      */
     public function getCellFeed(array $query = array())
     {

--- a/src/Google/Spreadsheet/WorksheetFeed.php
+++ b/src/Google/Spreadsheet/WorksheetFeed.php
@@ -31,7 +31,7 @@ class WorksheetFeed extends ArrayIterator
     /**
      * Worksheet feed xml object
      * 
-     * @var \SimpleXMLElement
+     * @var SimpleXMLElement
      */
     private $xml;
 
@@ -45,6 +45,7 @@ class WorksheetFeed extends ArrayIterator
         $this->xml = new SimpleXMLElement($xml);
 
         $worksheets = array();
+        /** @noinspection PhpUndefinedFieldInspection */
         foreach ($this->xml->entry as $entry) {
             $worksheet = new Worksheet($entry);
             $worksheet->setPostUrl($this->getPostUrl());
@@ -87,11 +88,13 @@ class WorksheetFeed extends ArrayIterator
      * 
      * @param string $title name of the worksheet
      * 
-     * @return \Google\Spreadsheet\Worksheet
+     * @return Worksheet
      */
     public function getByTitle($title)
     {
+        /** @noinspection PhpUndefinedFieldInspection */
         foreach ($this->xml->entry as $entry) {
+            /** @noinspection PhpUndefinedFieldInspection */
             if ($entry->title->__toString() == $title) {
                 $worksheet = new Worksheet($entry);
                 $worksheet->setPostUrl($this->getPostUrl());


### PR DESCRIPTION
There were a few instances of missing, incorrect, or inconsistent documentation in the PHPDoc docblocks, which were causing PHPStorm to complain about accessing missing properties and methods, or simply not provide any hinting when working with Objects from the library. Barring some remaining complains about unused namespaces in the XML string literals, these should all be fixed now.

This is purely a tooling improvement. It doesn't modify the functionality or the API in any way.