### PR TITLE
added getById() in SpreadsheetFeed

### DIFF
--- a/src/Google/Spreadsheet/SpreadsheetFeed.php
+++ b/src/Google/Spreadsheet/SpreadsheetFeed.php
@@ -20,7 +20,7 @@ use ArrayIterator;
 use SimpleXMLElement;
 
 /**
- * Spreadsheet feed. 
+ * Spreadsheet feed.
  *
  * @package    Google
  * @subpackage Spreadsheet
@@ -30,14 +30,14 @@ class SpreadsheetFeed extends ArrayIterator
 {
     /**
      * The spreadsheet feed xml object
-     * 
+     *
      * @var \SimpleXMLElement
      */
     protected $xml;
 
     /**
      * Initializes the the spreadsheet feed object
-     * 
+     *
      * @param string $xml the raw xml string of a spreadsheet feed
      */
     public function __construct($xml)
@@ -52,18 +52,36 @@ class SpreadsheetFeed extends ArrayIterator
     }
 
     /**
-     * Gets a spreadhseet from the feed by its title. i.e. the name of 
+     * Gets a spreadhseet from the feed by its title. i.e. the name of
      * the spreadsheet in google drive. This method will return only the
      * first spreadsheet found with the specified title.
-     * 
+     *
      * @param string $title
-     * 
+     *
      * @return \Google\Spreadsheet\Spreadsheet|null
      */
     public function getByTitle($title)
     {
         foreach($this->xml->entry as $entry) {
             if($entry->title->__toString() == $title) {
+                return new Spreadsheet($entry);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets a spreadhseet from the feed by its id. Use this when you have two
+     * spreadsheets with same name where @getByTitle will not work as expected.
+     *
+     * @param string $id
+     *
+     * @return \Google\Spreadsheet\Spreadsheet|null
+     */
+    public function getById($id)
+    {
+        foreach($this->xml->entry as $entry) {
+            if($entry->id->__toString() == $id) {
                 return new Spreadsheet($entry);
             }
         }


### PR DESCRIPTION
If drive has two sheets with similar name `getByTitle()` will always return the first sheet with the name specified. So there's no easy way to access second sheet. `getById()` will be helpful here as it will search sheet by its id which is unique.