### PR TITLE
Added ability to access public spreadsheets.

### DIFF
--- a/src/Google/Spreadsheet/DefaultServiceRequest.php
+++ b/src/Google/Spreadsheet/DefaultServiceRequest.php
@@ -73,6 +73,16 @@ class DefaultServiceRequest implements ServiceRequestInterface
     }
 
     /**
+     * Get access token
+     * 
+     * @return string
+     */
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
+
+    /**
      * Get request headers
      * 
      * @return array

--- a/src/Google/Spreadsheet/PublicSpreadsheetService.php
+++ b/src/Google/Spreadsheet/PublicSpreadsheetService.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright 2013 Asim Liaquat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Google\Spreadsheet;
+
+/**
+ * Spreadsheet Service.
+ *
+ * @package    Google
+ * @subpackage Spreadsheet
+ * @author     Asim Liaquat <asimlqt22@gmail.com>
+ */
+class PublicSpreadsheetService
+{
+    /**
+     * Fetches a list of spreadhsheet spreadsheets from google drive.
+     *
+     * @return \Google\Spreadsheet\SpreadsheetFeed
+     */
+    public function getSpreadsheets()
+    {
+        $instance = ServiceRequestFactory::getInstance();
+        $key = $instance->getAccessToken();
+        return new SpreadsheetFeed(
+            $instance->get("feeds/worksheets/{$key}/public/full")
+        );
+    }
+
+    /**
+     * Returns a list feed of the specified worksheet.
+     *
+     * @see \Google\Spreadsheet\Worksheet::getWorksheetId()
+     *
+     * @param string $worksheetId
+     *
+     * @return \Google\Spreadsheet\ListFeed
+     */
+    public function getListFeed($worksheetId)
+    {
+        $instance = ServiceRequestFactory::getInstance();
+        $key = $instance->getAccessToken();
+        return new ListFeed(
+            $instance->get("feeds/list/{$key}/{$worksheetId}/public/full")
+        );
+    }
+
+    /**
+     * Returns a cell feed of the specified worksheet.
+     *
+     * @see \Google\Spreadsheet\Worksheet::getWorksheetId()
+     *
+     * @param string $worksheetId
+     *
+     * @return \Google\Spreadsheet\CellFeed
+     */
+    public function getCellFeed($worksheetId)
+    {
+        $instance = ServiceRequestFactory::getInstance();
+        $key = $instance->getAccessToken();
+        return new CellFeed(
+            $instance->get("feeds/cells/{$key}/{$worksheetId}/public/full")
+        );
+    }
+}


### PR DESCRIPTION
These are spreadsheets that have been published using the "Publish to the web" feature (not to be confused with those that have been made public using the "Public on the web" visibility option).

The ServiceRequest should be initialised with the sheet's key as its $accessToken, and $tokenType should be set to "basic".  You can then use the PublicSpreadsheetService to access the sheet.

Example:

```php
use Google\Spreadsheet\DefaultServiceRequest;
use Google\Spreadsheet\ServiceRequestFactory;

$serviceRequest = new DefaultServiceRequest($key, "basic");
ServiceRequestFactory::setInstance($serviceRequest);
$spreadsheetService = new Google\Spreadsheet\PublicSpreadsheetService();

// Get cells from first worksheet.  Not sure if non-numeric ids can be used here - the API docs specify a number should be used.
$cells = $spreadsheetService->getCellFeed(1);
```

I have exposed the $accessToken in the DefaultServiceRequest class, via a new getAccessToken() method, so that this can be accessed from the PublicSpreadsheetService class.

The new PublicSpreadsheetService class is based on SpreadsheetService, but does not implement the getSpreadsheetById() method, as this is not possible and makes no sense in the context of a public sheet.  There seemed little point extending from the SpreadsheetService class, as the code is not sufficiently re-usable between the two contexts.