### PR TITLE
getXml added throughout the project to use the XML without data loss + get formula / raw value of cells

### DIFF
--- a/src/Google/Spreadsheet/CellEntry.php
+++ b/src/Google/Spreadsheet/CellEntry.php
@@ -132,6 +132,19 @@ class CellEntry
     }
 
     /**
+     * Get the row number fo this cell
+     * 
+     * @return int
+     */
+    public function getInputValue()
+    {
+
+      $inputValue = Util::extractAttributeFromXml($this->xml, 'inputValue', 'gs', 'cell');
+      return $inputValue;
+
+    }
+    
+    /**
      * Get the cell identifier e.g. A1
      * 
      * @return string

--- a/src/Google/Spreadsheet/CellEntry.php
+++ b/src/Google/Spreadsheet/CellEntry.php
@@ -88,7 +88,17 @@ class CellEntry
             $this->column
         );
     }
-        
+
+    /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+
     /**
      * Get the row number fo this cell
      * 

--- a/src/Google/Spreadsheet/CellEntry.php
+++ b/src/Google/Spreadsheet/CellEntry.php
@@ -132,9 +132,9 @@ class CellEntry
     }
 
     /**
-     * Get the row number fo this cell
+     * Get the the <gs:cell inputValue="FORMULA"> of this cell from its XML
      * 
-     * @return int
+     * @return string
      */
     public function getInputValue()
     {
@@ -143,7 +143,7 @@ class CellEntry
       return $inputValue;
 
     }
-    
+
     /**
      * Get the cell identifier e.g. A1
      * 

--- a/src/Google/Spreadsheet/CellFeed.php
+++ b/src/Google/Spreadsheet/CellFeed.php
@@ -54,6 +54,16 @@ class CellFeed
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Get the feed entries
      * 
      * @return array \Google\Spreadsheet\CellEntry

--- a/src/Google/Spreadsheet/ListEntry.php
+++ b/src/Google/Spreadsheet/ListEntry.php
@@ -54,6 +54,16 @@ class ListEntry
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Get the values of this list entry
      * 
      * @return array

--- a/src/Google/Spreadsheet/ListFeed.php
+++ b/src/Google/Spreadsheet/ListFeed.php
@@ -47,6 +47,16 @@ class ListFeed
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Get the post url for this feed
      * 
      * @return string

--- a/src/Google/Spreadsheet/Spreadsheet.php
+++ b/src/Google/Spreadsheet/Spreadsheet.php
@@ -48,6 +48,16 @@ class Spreadsheet
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Get the spreadsheet id
      * 
      * @return string

--- a/src/Google/Spreadsheet/SpreadsheetFeed.php
+++ b/src/Google/Spreadsheet/SpreadsheetFeed.php
@@ -52,6 +52,16 @@ class SpreadsheetFeed extends ArrayIterator
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Gets a spreadhseet from the feed by its title. i.e. the name of 
      * the spreadsheet in google drive. This method will return only the
      * first spreadsheet found with the specified title.

--- a/src/Google/Spreadsheet/Util.php
+++ b/src/Google/Spreadsheet/Util.php
@@ -58,4 +58,23 @@ class Util
         throw new Exception('No link found with rel "'.$rel.'"');
     }
 
+    /**
+     * Get a specific attribute in a namespaced tag
+     * @param  \SimpleXMLElement $xml            
+     * @param  string $attributeFocus 
+     * @param  string $namespaceFocus 
+     * @param  string $tagFocus       
+     * @return string 
+     */
+    public static function extractAttributeFromXml($xml, $attributeFocus, $namespaceFocus, $tagFocus)
+    {
+
+      $namespace = $xml->getNamespaces(true);
+      $attributes = $xml->children($namespace[$namespaceFocus])->{$tagFocus}->attributes();
+      
+      $finalAttribute = $attributes[$attributeFocus];
+      return $finalAttribute->__toString();
+
+    }
+    
 }

--- a/src/Google/Spreadsheet/Worksheet.php
+++ b/src/Google/Spreadsheet/Worksheet.php
@@ -49,6 +49,16 @@ class Worksheet
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Get the worksheet id. Returns the full url.
      *
      * @return string

--- a/src/Google/Spreadsheet/WorksheetFeed.php
+++ b/src/Google/Spreadsheet/WorksheetFeed.php
@@ -54,6 +54,16 @@ class WorksheetFeed extends ArrayIterator
     }
 
     /**
+     * Get the raw XML
+     * 
+     * @return int
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+    
+    /**
      * Get the worksheet feed post url
      * 
      * @return string


### PR DESCRIPTION
It can be useful to get the XML that's processed by the package sometimes. For instance, the package doesn't allow to directly get the inputValue provided by the Google Sheets API (which can contain formulas). You can also use the `$entry->getXml->asxml()` attribute of SimpleXMLElement and process the raw XML however you want

    $cell_feed = $worksheet->getCellFeed();

    foreach ($cell_feed->getEntries() as $entry) {

        $column = $entry->getColumn();
        $row = $entry->getRow();
        
        // Fork here

        $xml = $entry->getXml()->asxml(); // This will get the raw XML in a string (not used in this example)

        $ns = $entry->getXml()->getNamespaces(true);
        $attributes = $entry->getXml()->children($ns['gs'])->cell->attributes();
        $values[] = $attributes['inputValue']; // $values will be an array containing all the raw formulas of the cell feed
       
       // End of fork
       

    }