### PR TITLE
Add conditional check to Util.php

### DIFF
--- a/src/Google/Spreadsheet/Util.php
+++ b/src/Google/Spreadsheet/Util.php
@@ -73,7 +73,9 @@ class Util
         $namespacePrefix,
         $attribute
     ) {
-        return $xml->children($namespacePrefix, true)->attributes()[$attribute]->__toString();
+        $attr = $xml->children($namespacePrefix, true)->attributes()[$attribute];
+        
+        return $attr ? $attr->__toString() : null;
     }
     
 }


### PR DESCRIPTION
To avoid __toString errors on null attributes I added a conditional check to the extractAttributeFromXml static util.